### PR TITLE
Added a helper class as a thin wrapper for the library

### DIFF
--- a/Pluralize.NET.Tests/Pluralize.NET.Tests.csproj
+++ b/Pluralize.NET.Tests/Pluralize.NET.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Pluralize.NET.Tests/Pluralize.NET.Tests.csproj
+++ b/Pluralize.NET.Tests/Pluralize.NET.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Pluralize.NET.Tests/PluralizeHelperTests.cs
+++ b/Pluralize.NET.Tests/PluralizeHelperTests.cs
@@ -1,0 +1,108 @@
+﻿using NUnit.Framework;
+
+namespace Pluralize.NET.Tests
+{
+    [TestFixture]
+    public class PluralizeHelperTests
+    {
+        [Test]
+        public void Pluralize_Integer_Plural()
+        {
+            var expected = "Found 10 matches";
+
+            var actual = $"Found {10.Pluralize("matches")}";
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Pluralize_Integer_Singulare()
+        {
+            var expected = "Found 1 match";
+
+            var actual = $"Found {1.Pluralize("matches")}";
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Pluralize_ZeroInteger_Plural()
+        {
+            var expected = "Found 0 matches";
+
+            var actual = $"Found {0.Pluralize("matches")}";
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Pluralize_Double_Plural()
+        {
+            var expected = $"Revenew of {10.5} milions";
+
+            var actual = $"Revenew of {10.5.Pluralize("milions")}";
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Pluralize_Double_Singulare()
+        {
+            var expected = $"Revenew of {1.0} milion";
+
+            var actual = $"Revenew of {1.0.Pluralize("milions")}";
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Pluralize_ZeroDouble_Plural()
+        {
+            var expected = $"Revenew of {0.0} milions";
+
+            var actual = $"Revenew of {0.0.Pluralize("milions")}";
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Pluralize_Fraction_Singular()
+        {
+            var expected = $"Revenew of {0.1} milion";
+
+            var actual = $"Revenew of {0.1.Pluralize("milions")}";
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Pluralize_String_Plural()
+        {
+            var expected = "Found 10 matches";
+
+            var actual = $"Found 10 {"matches".Pluralize(10)}";
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Pluralize_String_Singulare()
+        {
+            var expected = "Found 1 match";
+
+            var actual = $"Found 1 {"matches".Pluralize(1)}";
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Pluralize_String_ZeroCount_Plural()
+        {
+            var expected = "Found 0 matches";
+
+            var actual = $"Found 0 {"matches".Pluralize(0)}";
+
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/Pluralize.NET/PluralizeHelper.cs
+++ b/Pluralize.NET/PluralizeHelper.cs
@@ -1,0 +1,25 @@
+﻿namespace Pluralize.NET
+{
+    public static class PluralizeHelper
+    {
+        public static string Pluralize(this int count, string unit)
+        {
+            return new Pluralizer().Format(unit, count, true);
+        }
+
+        public static string Pluralize(this float count, string unit)
+        {
+            return new Pluralizer().Format(unit, (int)count, true);
+        }
+
+        public static string Pluralize(this double count, string unit)
+        {
+            return new Pluralizer().Format(unit, (int)count, true);
+        }
+
+        public static string Pluralize(this string unit, int count)
+        {
+            return new Pluralizer().Format(unit, count);
+        }
+    }
+}

--- a/Pluralize.NET/PluralizeHelper.cs
+++ b/Pluralize.NET/PluralizeHelper.cs
@@ -7,14 +7,11 @@
             return new Pluralizer().Format(unit, count, true);
         }
 
-        public static string Pluralize(this float count, string unit)
-        {
-            return new Pluralizer().Format(unit, (int)count, true);
-        }
-
         public static string Pluralize(this double count, string unit)
         {
-            return new Pluralizer().Format(unit, (int)count, true);
+            if ((int)count == 0 && count != 0)
+                return $"{count} {new Pluralizer().Format(unit, 1, false)}";
+            return $"{count} {new Pluralizer().Format(unit, (int)count, false)}";
         }
 
         public static string Pluralize(this string unit, int count)


### PR DESCRIPTION
Hi,

First of all thanks for your useful port. I was very helpful in my recent project.

I used the library with a help class as a thin wrapper, which I would like to contribute to the project.

## Here's how to use

Include the namespace:
```C#
using Pluralize.NET
```

```C#
// Example of an integer
Console.WriteLine($"Found {10.Pluralize("matches")}");
// ouput: Found 10 matches

// Example of a string
Console.WriteLine($"Found 1 {"matches".Pluralize(1)}");
// ouput: Found 1 match
```

See the tests for more examples.

Kind regards,
Thomas Volden